### PR TITLE
FIX: name clipping for `PokemonListItemComponent`

### DIFF
--- a/src/app/shared/pokemon-list-item/pokemon-list-item.component.css
+++ b/src/app/shared/pokemon-list-item/pokemon-list-item.component.css
@@ -2,8 +2,8 @@
   display: flex;
   flex-direction: column;
   aspect-ratio: 1;
-  max-width: 130px;
-  width: 30vw;
+  max-width: 136px;
+  width: 35vw;
   padding: 8px;
   border-radius: 8px;
   border: rgb(0 0 0 / 0.15) solid 1px;
@@ -18,7 +18,8 @@
 }
 
 .pokemon-sprite {
-
+  height: 96px;
+  width: 96px;
 }
 
 .pokemon-top-bar {


### PR DESCRIPTION
name in `PokemonListItemComponent` no longer clips out of container at screen widths >= 360px